### PR TITLE
chore: migrate CODEOWNERS to new component team (26Q2)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 
 # ============ Default Owners ============
 # These teams are responsible for reviewing all changes
-* @hardcoretech/scrum-shield
+* @hardcoretech/platform


### PR DESCRIPTION
Auto-generated CODEOWNERS migration for 26Q2 team reorganization.

Replaces legacy scrum team references with the new component team assignment, or adds a catch-all if none existed.

See the org-level migration plan for full context.